### PR TITLE
Include .formatter.exs into package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,7 @@ defmodule CVA.MixProject do
       },
       files:
         ~w(lib) ++
-          ~w(CHANGELOG.md LICENSE.md mix.exs README.md)
+          ~w(CHANGELOG.md LICENSE.md mix.exs README.md .formatter.exs)
     ]
   end
 end


### PR DESCRIPTION
Currently we need to "copy" formatter rules `:locals_without_parens` into our project's ".formatter.exs".

This change will allow projects to just include `:cva` into their local formatter's `:import_deps` as
```elixir
# .formatter.exs
[
  import_deps: [:cva]
]
```