### PR TITLE
🩹 add `.formatter.exs` config file to hex package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,7 @@ defmodule CVA.MixProject do
       },
       files:
         ~w(lib) ++
-          ~w(CHANGELOG.md LICENSE.md mix.exs README.md)
+          ~w(CHANGELOG.md LICENSE.md mix.exs README.md .formatter.exs)
     ]
   end
 end


### PR DESCRIPTION
# Issue
When using `cva` as hex dependency and using the `CVA.Component` approach, code formatting as documented in https://hexdocs.pm/cva/CVA.Component.html does not work.

# Cause
The `.formatter.exs` file is missing from the published hex package.

# Fix
Add `.formatter.exs` to the `mix.exs` `package` declaration.